### PR TITLE
Fix ajax loading indication

### DIFF
--- a/src/stylus/App.styl
+++ b/src/stylus/App.styl
@@ -2678,6 +2678,8 @@ input.autocomplete {
 
   &.ajax-loading {
     background-image url(../images/loading.gif)
+    background-repeat no-repeat
+    background-position right center
   }
 }
 


### PR DESCRIPTION
It used to replicate the loading image over the complete field.
This makes sure there is only one image in the input field indicating
something is requested in the background.

Example: add related issues