### PR TITLE
feat: Updated Docker image MySQL 8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - ./src/assets:/usr/src/redmine/public/themes/minimalflat2
   mysql:
     container_name: mysql_minimalflat2
-    image: mysql:5.7
+    image: mysql:8.0
     restart: always
     environment:
       TZ: Asia/Tokyo
@@ -27,4 +27,4 @@ services:
       MYSQL_DATABASE: redmine_minimalflat2
       MYSQL_USER: redmine_minimalflat2
       MYSQL_PASSWORD: redmine_minimalflat2
-    command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_bin
+    command: mysqld --default-authentication-plugin=mysql_native_password --character-set-server=utf8mb4 --collation-server=utf8mb4_bin


### PR DESCRIPTION
refs #160

With MySQL 8, the following error occurs in the Redmine container.

```
Mysql2::Error: RSA Encryption not supported - caching_sha2_password plugin was built with GnuTLS support
```

The option `--default-authentication-plugin = mysql_native_password` is needed to work around this issue.